### PR TITLE
ci: ワークフローのスケジュール整理とPRブランチ名のユニーク化 (Issue #316)

### DIFF
--- a/.github/workflows/generate_v3.yml
+++ b/.github/workflows/generate_v3.yml
@@ -2,7 +2,7 @@ name: Generate-v3
 
 on:
   schedule:
-    - cron: '0 0 1 * *' # 毎月1日の00:00に実行
+    - cron: '0 15 * * 6' # 毎週日曜日のJST 00:00 (UTC 土曜日の 15:00) に実行
   workflow_dispatch:
     inputs:
       generate:
@@ -44,6 +44,11 @@ jobs:
         run: |
           python script/v3/main.py
 
+      - name: Set branch name
+        if: ${{ github.event_name == 'schedule' || inputs.create_pr == 'true' }}
+        id: branch_name
+        run: echo "branch=feature/update-timetable-v3-$(TZ='Asia/Tokyo' date +'%Y%m%d')" >> $GITHUB_OUTPUT
+
       - name: Create pull request
         if: ${{ github.event_name == 'schedule' || inputs.create_pr == 'true' }}
         uses: peter-evans/create-pull-request@v7
@@ -51,5 +56,5 @@ jobs:
           commit-message: "Update timetable v3"
           title: "Update timetable v3"
           body: "Update timetable v3"
-          branch: "feature/update-timetable-v3"
+          branch: ${{ steps.branch_name.outputs.branch }}
           delete-branch: true

--- a/.github/workflows/pre_cache_v3.yml
+++ b/.github/workflows/pre_cache_v3.yml
@@ -2,7 +2,7 @@ name: Pre-Cache-v3
 
 on:
   schedule:
-    - cron: '0 15 * * *' # 毎日JST 00:00 (UTC 15:00) に実行
+    - cron: '0 15 * * 0-5' # 月〜土曜日のJST 00:00 (UTC 日〜金曜日の 15:00) に実行
   workflow_dispatch:
 
 jobs:
@@ -32,8 +32,7 @@ jobs:
 
       - name: Run Pre-Cache
         run: |
-          # 曜日 (1-7) を取得し、0-based のインデックス (0-6) に変換
-          # 7分割して日替わりで事前取得
-          INDEX=$(( $(date +%u) - 1 ))
-          echo "Processing part index: $INDEX (Total parts: 7)"
-          python script/v3/main.py --total-parts 7 --part-index $INDEX
+          # JST での曜日 (1:月-6:土) を取得し、0-based のインデックス (0-5) に変換
+          INDEX=$(( $(TZ='Asia/Tokyo' date +%u) - 1 ))
+          echo "Processing part index: $INDEX (Total parts: 6)"
+          python script/v3/main.py --total-parts 6 --part-index $INDEX


### PR DESCRIPTION
# 概要 (Goal Description)
GitHub Actions のワークフローを整理し、事前キャッシュと時刻表生成のスケジュールを一週間周期で同期させました。また、PR のブランチ名に日付を含めることでユニーク化し、以前の PR がマージされていない場合の上書きを防止しました。

Fixes #316

# 変更内容 (Proposed Changes)

### GitHub Actions Workflows
#### [MODIFY] [.github/workflows/pre_cache_v3.yml](file:///e:/work/BusTimeTableDatabase/.github/workflows/pre_cache_v3.yml)
- 実行スケジュールを「毎日」から **月〜土曜日 (JST)** に変更
- キャッシュ分割数を 7 から **6** に変更
- `TZ='Asia/Tokyo'` を使用し、正確な JST 曜日によるインデックス計算を実装

#### [MODIFY] [.github/workflows/generate_v3.yml](file:///e:/work/BusTimeTableDatabase/.github/workflows/generate_v3.yml)
- 実行スケジュールを「毎月1日」から **毎週日曜日 (JST)** に変更
- PR のブランチ名に `YYYYMMDD` 形式の日付を付与し、毎週ユニークなブランチで PR が作成されるように修正

# 検証結果 (Verification Plan)
- `cron` 設定の JST-UTC 対応関係の確認（0 15 * * 0-5 -> JST 月-土 / 0 15 * * 6 -> JST 日）
- 日付・インデックス計算のシェルスクリプトロジックの検証
- `workflow_dispatch` による手動トリガーの正常動作を確認
